### PR TITLE
Feature/export talents csv

### DIFF
--- a/src/modules/leader/pages/LeaderPage.tsx
+++ b/src/modules/leader/pages/LeaderPage.tsx
@@ -1,12 +1,12 @@
 import { useState, useMemo } from "react"
-import { AlertCircle, Users2, TrendingUp, AlertTriangle, Award, FileText } from "lucide-react"
+import { AlertCircle, Users2, TrendingUp, AlertTriangle, Award, Download } from "lucide-react"
 import { Skeleton } from "@/shared/components/ui/skeleton"
 import { Alert, AlertDescription, AlertTitle } from "@/shared/components/ui/alert"
 import { Button } from "@/shared/components/ui/button"
 import StatsCard from "@/shared/components/common/StatsCard"
 import FilterControls, { FilterConfig } from "@/shared/components/common/FilterControls"
 import { useDataFilter } from "@/shared/hooks/useDataFilter"
-import { useGetTeamMembersQuery } from "../store/leaderApi"
+import { useGetTeamMembersQuery, useLazyExportTalentsReportQuery } from "../store/leaderApi"
 import TrainingTracksDialog from "../components/TrainingTracksDialog"
 import TeamMemberCard from "../components/TeamMemberCard"
 // 1. Import useToast
@@ -17,62 +17,48 @@ export default function LeaderDashboard() {
   // 2. Initialize toast hook
   const { toast } = useToast()
 
-  // --- Mock HTTP Request Function ---
-  // 3. Function to simulate an API call for generating the report
-  const generateReport = (): Promise<boolean> => {
-    // 90% chance of success
-    const isSuccess = Math.random() < 0.9
+  const [triggerExport, { isLoading: isExporting }] = useLazyExportTalentsReportQuery()
 
-    // Simulate network latency
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(isSuccess)
-      }, 1500) // 1.5s delay
-    })
-  }
-
-  // 4. Handler for the button click
   const handleGenerateReport = async () => {
-    const loadingToast = toast({
+    toast({
       title: "Generating Report...",
       description: "Please wait while your team overview report is being prepared.",
       variant: "default",
-      duration: 999999, // Keep open until updated
     })
 
     try {
-      const success = await generateReport()
+      const response = await triggerExport().unwrap()
 
-      if (success) {
-        loadingToast.update({
-          title: "✅ Report Generated!",
-          description: "The Team Overview report has been successfully created and is ready for download.",
-          variant: "default",
-          duration: 5000,
-          id: '', // Allow it to auto-remove
-        })
-      } else {
-        loadingToast.update({
-          title: "❌ Report Generation Failed",
-          description: "An unexpected error occurred while creating the report. Please try again.",
-          variant: "destructive",
-          duration: 5000,
-          id: 'undefined', // Allow it to auto-remove
+      // Create a temporary link for download
+      const url = window.URL.createObjectURL(response)
+      const link = document.createElement("a")
+      link.href = url
 
-        })
-      }
+      // Suggested filename
+      const date = new Date().toISOString().slice(0, 10)
+      link.setAttribute("download", `talents_report_${date}.csv`)
+
+      document.body.appendChild(link)
+      link.click()
+
+      // Cleanup
+      link.remove()
+      window.URL.revokeObjectURL(url)
+
+      toast({
+        title: "✅ Report Generated",
+        description: "The talents report has been successfully downloaded.",
+        variant: "default",
+      })
     } catch (error) {
-      loadingToast.update({
-        title: "❌ Network Error",
-        description: "Could not connect to the server to generate the report." + error,
+      console.error("Error exporting CSV:", error)
+      toast({
+        title: "❌ Export Failed",
+        description: "Could not generate the report. Please try again.",
         variant: "destructive",
-        duration: 5000,
-        id: 'undefined', // Allow it to auto-remove
-
       })
     }
   }
-  // --- End Mock HTTP Request Function ---
 
   // RTK Query hook
   const {
@@ -260,9 +246,11 @@ export default function LeaderDashboard() {
           <h2 className="text-xl font-semibold">Team Progress</h2>
           <Button
             onClick={handleGenerateReport}
-            variant="ghost"
+            variant="outline"
+            disabled={isExporting}
           >
-            <FileText className="mr-2 h-4 w-4" /> Generate Report
+            <Download className="mr-2 h-4 w-4" />
+            {isExporting ? "Exporting..." : "Export CSV"}
           </Button>
         </div>
 

--- a/src/modules/leader/store/leaderApi.ts
+++ b/src/modules/leader/store/leaderApi.ts
@@ -144,6 +144,15 @@ export const leaderApi = baseApi.injectEndpoints({
         body,
       }),
     }),
+    
+    // Export talents report as CSV
+    exportTalentsReport: builder.query<Blob, void>({
+      query: () => ({
+        url: "/leader/talents/export/",
+        responseHandler: (response) => response.blob(),
+        cache: "no-cache",
+      }),
+    }),
   }),
 })
 
@@ -157,4 +166,5 @@ export const {
   useGetTrainingTrackDetailQuery,
   useAssignCourseMutation,
   useSendTeamMessageMutation,
+  useLazyExportTalentsReportQuery,
 } = leaderApi


### PR DESCRIPTION
# PR: Implement Talent Report Export to CSV
## Description
This PR implements the "Export Report" functionality in the Leaders Dashboard. It connects the frontend to the existing backend CSV export endpoint, allowing leaders to download a structured report of their direct subordinates' progress.
## Ticket / Issue Reference
- **Feature:** Talent CSV Export
- **Endpoint:** `/api/leader/talents/export/`
## Key Changes
### 1. API Infrastructure (`leaderApi.ts`)
- Added `exportTalentsReport` query to the `leaderApi` store using RTK Query.
- Implemented `responseHandler: (response) => response.blob()` to correctly process data as a binary file.
- Exported `useLazyExportTalentsReportQuery` hook.
### 2. UI Implementation (`LeaderPage.tsx`)
- Replaced mock report generation with the real API call.
- Implemented download trigger using `URL.createObjectURL` for the received Blob.
- **Improved UX:**
  - Added **"Export CSV"** button with a loading state.
  - Button is disabled while exporting to prevent multiple requests.
  - Integrated `Download` icon from `lucide-react`.
  - Added `toast` notifications for progress and error handling.
- **Localization:** Standardized all UI messages/toasts to English to match the repository's language.
<img width="1635" height="970" alt="Screenshot 2026-04-10 at 12 09 04 PM" src="https://github.com/user-attachments/assets/56cb068f-f562-43b1-ba95-9dfe3c315963" />
<img width="1115" height="464" alt="Screenshot 2026-04-10 at 12 29 54 PM" src="https://github.com/user-attachments/assets/f6df655d-1275-42ca-b8ed-3e6e4fb1ead0" />
