### PR TITLE
Feature: filters view admin

### DIFF
--- a/src/modules/leader/pages/LeaderPage.tsx
+++ b/src/modules/leader/pages/LeaderPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react"
-import { AlertCircle, Users2, TrendingUp, AlertTriangle, Award, Download } from "lucide-react"
+import { AlertCircle, Users2, TrendingUp, AlertTriangle, Award, Download, Zap } from "lucide-react"
 import { Skeleton } from "@/shared/components/ui/skeleton"
 import { Alert, AlertDescription, AlertTitle } from "@/shared/components/ui/alert"
 import { Button } from "@/shared/components/ui/button"
@@ -86,7 +86,19 @@ export default function LeaderDashboard() {
     data: teamMembers || [],
     searchFields: ["name"],
     sortField: "name",
-    itemsPerPage: 6
+    itemsPerPage: 6,
+    customFilters: useMemo(() => ({
+      performance: (member: any, value: string) => {
+        const p = member.completion_percentage || 0
+        switch (value) {
+          case "high": return p >= 75
+          case "medium": return p >= 25 && p < 75
+          case "low": return p > 0 && p < 25
+          case "none": return p === 0
+          default: return true
+        }
+      }
+    }), [])
   })
 
   // Extract unique roles
@@ -149,6 +161,18 @@ export default function LeaderDashboard() {
       options: [
         { value: "at_risk", label: "At Risk" },
         { value: "on_track", label: "On Track" }
+      ]
+    },
+    {
+      key: "performance",
+      label: "Performance",
+      placeholder: "Performance",
+      icon: Zap,
+      options: [
+        { value: "high", label: "High (> 75%)" },
+        { value: "medium", label: "Moderate (25-75%)" },
+        { value: "low", label: "Starting (< 25%)" },
+        { value: "none", label: "Not Started" }
       ]
     }
   ]

--- a/src/shared/components/common/CoursesDashboard.tsx
+++ b/src/shared/components/common/CoursesDashboard.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react"
 import StatsCard from "@/shared/components/common/StatsCard"
 import CourseCard from "@/shared/components/common/CourseCard"
-import { BookOpen, Award, TrendingUp, Monitor } from "lucide-react"
+import { BookOpen, Award, TrendingUp, Monitor, Activity } from "lucide-react"
 import { useGetEnrolledCoursesQuery } from "../../store/coursesApi"
 import { Skeleton } from "@/shared/components/ui/skeleton"
 import { Alert, AlertDescription, AlertTitle } from "@/shared/components/ui/alert"
@@ -35,7 +35,19 @@ export default function CoursesDashboard() {
     data: courses || [],
     searchFields: ["title", "description"],
     sortField: "title",
-    itemsPerPage: 9
+    itemsPerPage: 9,
+    customFilters: useMemo(() => ({
+      progress: (course: any, value: string) => {
+        const p = course.progress_percentage || 0
+        switch (value) {
+          case "lt25": return p < 25
+          case "lt50": return p < 50
+          case "lt75": return p < 75
+          case "completed": return p === 100
+          default: return true
+        }
+      }
+    }), [])
   })
 
   // Calculate progress locally from courses data
@@ -88,6 +100,18 @@ export default function CoursesDashboard() {
       placeholder: "All Platforms",
       icon: Monitor,
       options: platforms.map(platform => ({ value: platform, label: platform }))
+    },
+    {
+      key: "progress",
+      label: "Progress",
+      placeholder: "All Progress",
+      icon: Activity,
+      options: [
+        { value: "lt25", label: "Less than 25%" },
+        { value: "lt50", label: "Less than 50%" },
+        { value: "lt75", label: "Less than 75%" },
+        { value: "completed", label: "Completed" }
+      ]
     }
   ]
 

--- a/src/shared/components/common/FilterControls.tsx
+++ b/src/shared/components/common/FilterControls.tsx
@@ -38,9 +38,9 @@ export default function FilterControls({
   className = ""
 }: FilterControlsProps) {
   return (
-    <div className={`flex flex-row gap-4 ${className}`}>
+    <div className={`flex flex-col lg:flex-row gap-4 ${className}`}>
       {/* Search Input */}
-      <div className="relative flex-1 max-w-md">
+      <div className="relative flex-1 w-full max-w-2xl">
         <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
         <Input
           type="text"
@@ -52,7 +52,7 @@ export default function FilterControls({
       </div>
 
       {/* Filters Row */}
-      <div className="flex flex-col sm:flex-row gap-3">
+      <div className="flex flex-col sm:flex-row gap-3 flex-wrap">
         {filters.map((filter) => {
           const Icon = filter.icon
           
@@ -62,7 +62,7 @@ export default function FilterControls({
               value={filterValues[filter.key] || "all"}
               onValueChange={(value) => onFilterChange(filter.key, value)}
             >
-              <SelectTrigger className="w-full sm:w-52">
+              <SelectTrigger className="w-full sm:w-44">
                 <div className="flex items-center gap-2">
                   {Icon && <Icon className="w-4 h-4" />}
                   <SelectValue placeholder={filter.placeholder} />

--- a/src/shared/hooks/useDataFilter.ts
+++ b/src/shared/hooks/useDataFilter.ts
@@ -6,13 +6,15 @@ interface UseDataFilterOptions<T> {
   searchFields: (keyof T)[]
   sortField: keyof T
   itemsPerPage?: number
+  customFilters?: Record<string, (item: T, value: string) => boolean>
 }
 
 export function useDataFilter<T>({
   data,
   searchFields,
   sortField,
-  itemsPerPage = 9
+  itemsPerPage = 9,
+  customFilters
 }: UseDataFilterOptions<T>) {
   const [searchTerm, setSearchTerm] = useState("")
   const [filters, setFilters] = useState<Record<string, string>>({})
@@ -32,6 +34,12 @@ export function useDataFilter<T>({
       // Dynamic filters
       const matchesFilters = Object.entries(filters).every(([key, value]) => {
         if (value === "all") return true
+        
+        // Use custom filter if provided
+        if (customFilters && customFilters[key]) {
+          return customFilters[key](item, value)
+        }
+        
         return item[key as keyof T] === value
       })
 
@@ -49,7 +57,7 @@ export function useDataFilter<T>({
     })
 
     return filtered
-  }, [data, searchTerm, filters, sortOrder, searchFields, sortField])
+  }, [data, searchTerm, filters, sortOrder, searchFields, sortField, customFilters])
 
   // Pagination
   const totalPages = Math.ceil(filteredAndSortedData.length / itemsPerPage)


### PR DESCRIPTION
Feature: Admin Filters – Performance View

Overview

This PR introduces a new performance filter in the Admin view that calculates the overall performance across all courses. It enhances the filtering system by allowing admins to better analyze aggregated results.

What’s Included

* Added a performance filter that computes overall course performance
* Enabled compatibility with existing filters (can be combined with others)
* Integrated the filter into the Admin filters view

Why This Matters

Admins can now:

* Get a quick overview of user/course performance
* Apply multiple filters simultaneously for more precise insights
* Improve decision-making based on aggregated data

How to Test

1. Go to the Admin panel
2. Open the filters section
3. Apply the Performance filter
4. Combine it with other filters (e.g., course, date, etc.)
5. Verify that results update correctly and reflect aggregated performance

Notes

* Performance is calculated based on the overall results of selected courses
<img width="1213" height="162" alt="image" src="https://github.com/user-attachments/assets/fb08ea0f-6642-4aaa-a8ff-52cdc8cefc3e" />
