### PR TITLE
Title: feat: implement grid/list view toggle for dashboards and catalog

### DIFF
--- a/src/modules/consultant/pages/CatalogPage.tsx
+++ b/src/modules/consultant/pages/CatalogPage.tsx
@@ -1,14 +1,15 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { useGetAllCoursesQuery, useGetEnrolledCoursesQuery, useEnrollInCourseMutation, useGetCourseDetailsQuery } from '@/shared/store/coursesApi';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/shared/components/ui/card';
 import { Button } from '@/shared/components/ui/button';
 import { Badge } from '@/shared/components/ui/badge';
 import { toast } from 'sonner';
-import { Loader2, User, Monitor, AlertCircle } from 'lucide-react';
+import { Loader2, User, Monitor, AlertCircle, LayoutGrid, List } from 'lucide-react';
 import FilterControls, { FilterConfig } from '@/shared/components/common/FilterControls';
 import { useDataFilter } from '@/shared/hooks/useDataFilter';
 import { Alert, AlertDescription, AlertTitle } from '@/shared/components/ui/alert';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/shared/components/ui/dialog';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/shared/components/ui/Table';
 import { TrainingTrack } from '@/shared/store/coursesApi';
 import { BookOpen } from 'lucide-react';
 
@@ -17,6 +18,19 @@ export default function CatalogPage() {
   const { data: enrolledTracks = [], isLoading: isLoadingEnrolled } = useGetEnrolledCoursesQuery();
   const [enrollInCourse, { isLoading: isEnrolling }] = useEnrollInCourseMutation();
   const [selectedTrack, setSelectedTrack] = useState<TrainingTrack | null>(null);
+  const [viewMode, setViewMode] = useState<'cards' | 'table'>('cards');
+
+  useEffect(() => {
+    const saved = localStorage.getItem('catalogViewMode');
+    if (saved === 'cards' || saved === 'table') {
+      setViewMode(saved);
+    }
+  }, []);
+
+  const handleViewModeChange = (mode: 'cards' | 'table') => {
+    setViewMode(mode);
+    localStorage.setItem('catalogViewMode', mode);
+  };
 
   const enrolledIds = useMemo(() => {
     return new Set(enrolledTracks.map(t => t.id));
@@ -138,9 +152,31 @@ export default function CatalogPage() {
         onSortToggle={toggleSortOrder}
       />
 
-      {/* Results Count */}
-      <div className="text-sm text-muted-foreground">
-        Showing {paginatedData.length} of {filteredAndSortedData.length} training tracks
+      {/* Results Count & View Toggle */}
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-muted-foreground">
+          Showing {paginatedData.length} of {filteredAndSortedData.length} training tracks
+        </div>
+        <div className="flex items-center gap-1 bg-muted/50 p-1 rounded-md border">
+          <Button
+            variant={viewMode === 'cards' ? 'default' : 'ghost'}
+            size="sm"
+            className={`px-2 py-1 h-8 ${viewMode === 'cards' ? 'bg-primary text-primary-foreground hover:bg-primary/90' : 'text-muted-foreground'}`}
+            onClick={() => handleViewModeChange('cards')}
+            title="Cards View"
+          >
+            <LayoutGrid className="w-4 h-4" />
+          </Button>
+          <Button
+            variant={viewMode === 'table' ? 'default' : 'ghost'}
+            size="sm"
+            className={`px-2 py-1 h-8 ${viewMode === 'table' ? 'bg-primary text-primary-foreground hover:bg-primary/90' : 'text-muted-foreground'}`}
+            onClick={() => handleViewModeChange('table')}
+            title="Table View"
+          >
+            <List className="w-4 h-4" />
+          </Button>
+        </div>
       </div>
 
       {/* Track Cards */}
@@ -154,76 +190,151 @@ export default function CatalogPage() {
         </Alert>
       ) : (
         <>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {paginatedData.map((track) => {
-              const isEnrolled = enrolledIds.has(track.id);
+          {viewMode === 'cards' ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 animate-in fade-in duration-300">
+              {paginatedData.map((track) => {
+                const isEnrolled = enrolledIds.has(track.id);
 
-              return (
-                <Card
-                  key={track.id}
-                  className="flex flex-col h-full hover:shadow-md transition-shadow cursor-pointer"
-                  onClick={() => setSelectedTrack(track)}
-                >
-                  <CardHeader>
-                    <div className="flex justify-between items-start mb-2">
-                      <div className="flex items-center gap-1.5 text-sm text-muted-foreground font-medium">
-                        <User className="w-4 h-4" />
-                        {track.platform || 'General'}
-                      </div>
-                      {track.category && (
-                        <Badge variant="outline" className="text-xs">
-                          {track.category}
-                        </Badge>
-                      )}
-                    </div>
-                    <CardTitle className="text-xl line-clamp-1">{track.title}</CardTitle>
-                    <CardDescription className="line-clamp-2 h-10">
-                      {track.description || 'Enhance your professional skills with this specialized training track.'}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent className="flex-grow pt-2">
-                    <div className="space-y-3 text-sm">
-                      <div className="flex items-center justify-between text-muted-foreground">
-                        <span>Total Courses:</span>
-                        <span className="font-medium text-foreground">{track.total_courses || track.courses?.length || 0}</span>
-                      </div>
-                      {track.duration && (
-                        <div className="flex items-center justify-between text-muted-foreground">
-                          <span>Duration:</span>
-                          <span className="font-medium text-foreground">{track.duration}</span>
+                return (
+                  <Card
+                    key={track.id}
+                    className="flex flex-col h-full hover:shadow-md transition-shadow cursor-pointer"
+                    onClick={() => setSelectedTrack(track)}
+                  >
+                    <CardHeader>
+                      <div className="flex justify-between items-start mb-2">
+                        <div className="flex items-center gap-1.5 text-sm text-muted-foreground font-medium">
+                          <User className="w-4 h-4" />
+                          {track.platform || 'General'}
                         </div>
-                      )}
-                    </div>
-                  </CardContent>
-                  <CardFooter className="pt-4 mt-auto">
-                    {isEnrolled ? (
-                      <Button variant="outline" className="w-full" disabled>
-                        Enrolled
-                      </Button>
-                    ) : (
-                      <Button
-                        className="w-full bg-primary hover:bg-primary/90"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleEnroll(track.id);
-                        }}
-                        disabled={isEnrolling}
-                      >
-                        {isEnrolling ? (
-                          <>
-                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                            Enrolling...
-                          </>
-                        ) : (
-                          'Enroll Now'
+                        {track.category && (
+                          <Badge variant="outline" className="text-xs">
+                            {track.category}
+                          </Badge>
                         )}
-                      </Button>
-                    )}
-                  </CardFooter>
-                </Card>
-              );
-            })}
-          </div>
+                      </div>
+                      <CardTitle className="text-xl line-clamp-1">{track.title}</CardTitle>
+                      <CardDescription className="line-clamp-2 h-10">
+                        {track.description || 'Enhance your professional skills with this specialized training track.'}
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent className="flex-grow pt-2">
+                      <div className="space-y-3 text-sm">
+                        <div className="flex items-center justify-between text-muted-foreground">
+                          <span>Total Courses:</span>
+                          <span className="font-medium text-foreground">{track.total_courses || track.courses?.length || 0}</span>
+                        </div>
+                        {track.duration && (
+                          <div className="flex items-center justify-between text-muted-foreground">
+                            <span>Duration:</span>
+                            <span className="font-medium text-foreground">{track.duration}</span>
+                          </div>
+                        )}
+                      </div>
+                    </CardContent>
+                    <CardFooter className="pt-4 mt-auto">
+                      {isEnrolled ? (
+                        <Button variant="outline" className="w-full" disabled>
+                          Enrolled
+                        </Button>
+                      ) : (
+                        <Button
+                          className="w-full bg-primary hover:bg-primary/90"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleEnroll(track.id);
+                          }}
+                          disabled={isEnrolling}
+                        >
+                          {isEnrolling ? (
+                            <>
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                              Enrolling...
+                            </>
+                          ) : (
+                            'Enroll Now'
+                          )}
+                        </Button>
+                      )}
+                    </CardFooter>
+                  </Card>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="border rounded-md animate-in fade-in duration-300">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead className="hidden md:table-cell text-center">Author</TableHead>
+                    <TableHead className="hidden sm:table-cell text-center">Category</TableHead>
+                    <TableHead className="text-center">Total Courses</TableHead>
+                    <TableHead className="text-center">Action</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {paginatedData.map((track) => {
+                    const isEnrolled = enrolledIds.has(track.id);
+                    return (
+                      <TableRow 
+                        key={track.id}
+                        className="cursor-pointer hover:bg-muted/50"
+                        onClick={() => setSelectedTrack(track)}
+                      >
+                        <TableCell className="font-medium">
+                          <div className="line-clamp-1">{track.title}</div>
+                          {/* Show author/category on mobile */}
+                          <div className="md:hidden text-xs text-muted-foreground mt-1 flex gap-2">
+                            <span>{track.platform || 'General'}</span>
+                            {track.category && <span>• {track.category}</span>}
+                          </div>
+                        </TableCell>
+                        <TableCell className="hidden md:table-cell text-center text-muted-foreground">
+                          {track.platform || 'General'}
+                        </TableCell>
+                        <TableCell className="hidden sm:table-cell text-center">
+                          {track.category ? (
+                            <Badge variant="outline" className="text-xs font-normal">
+                              {track.category}
+                            </Badge>
+                          ) : (
+                            <span className="text-muted-foreground">-</span>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-center text-muted-foreground">
+                          {track.total_courses || track.courses?.length || 0}
+                        </TableCell>
+                        <TableCell className="text-center">
+                          {isEnrolled ? (
+                            <Button variant="outline" size="sm" disabled>
+                              Enrolled
+                            </Button>
+                          ) : (
+                            <Button
+                              size="sm"
+                              className="bg-primary hover:bg-primary/90"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleEnroll(track.id);
+                              }}
+                              disabled={isEnrolling}
+                            >
+                              {isEnrolling ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                'Enroll'
+                              )}
+                            </Button>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )}
 
           {/* Pagination Controls */}
           {totalPages > 1 && (

--- a/src/modules/consultant/pages/CatalogPage.tsx
+++ b/src/modules/consultant/pages/CatalogPage.tsx
@@ -283,7 +283,7 @@ export default function CatalogPage() {
                         className="cursor-pointer hover:bg-muted/50"
                         onClick={() => setSelectedTrack(track)}
                       >
-                        <TableCell className="font-medium">
+                        <TableCell className="font-medium max-w-[180px]">
                           <div className="line-clamp-1">{track.title}</div>
                           {/* Show info on mobile */}
                           <div className="md:hidden text-xs text-muted-foreground mt-1 space-y-1">
@@ -294,8 +294,8 @@ export default function CatalogPage() {
                             <div className="line-clamp-1 italic">{track.description}</div>
                           </div>
                         </TableCell>
-                        <TableCell className="hidden lg:table-cell text-muted-foreground text-sm max-w-sm">
-                          <div className="line-clamp-2">{track.description || '-'}</div>
+                        <TableCell className="hidden lg:table-cell text-muted-foreground text-sm max-w-[400px]">
+                          <div className="line-clamp-2 leading-relaxed">{track.description || '-'}</div>
                         </TableCell>
                         <TableCell className="hidden md:table-cell text-center text-muted-foreground">
                           {track.platform || 'General'}

--- a/src/modules/consultant/pages/CatalogPage.tsx
+++ b/src/modules/consultant/pages/CatalogPage.tsx
@@ -267,6 +267,7 @@ export default function CatalogPage() {
                 <TableHeader>
                   <TableRow>
                     <TableHead>Name</TableHead>
+                    <TableHead className="hidden lg:table-cell">Description</TableHead>
                     <TableHead className="hidden md:table-cell text-center">Author</TableHead>
                     <TableHead className="hidden sm:table-cell text-center">Category</TableHead>
                     <TableHead className="text-center">Total Courses</TableHead>
@@ -284,11 +285,17 @@ export default function CatalogPage() {
                       >
                         <TableCell className="font-medium">
                           <div className="line-clamp-1">{track.title}</div>
-                          {/* Show author/category on mobile */}
-                          <div className="md:hidden text-xs text-muted-foreground mt-1 flex gap-2">
-                            <span>{track.platform || 'General'}</span>
-                            {track.category && <span>• {track.category}</span>}
+                          {/* Show info on mobile */}
+                          <div className="md:hidden text-xs text-muted-foreground mt-1 space-y-1">
+                            <div className="flex gap-2">
+                              <span>{track.platform || 'General'}</span>
+                              {track.category && <span>• {track.category}</span>}
+                            </div>
+                            <div className="line-clamp-1 italic">{track.description}</div>
                           </div>
+                        </TableCell>
+                        <TableCell className="hidden lg:table-cell text-muted-foreground text-sm max-w-sm">
+                          <div className="line-clamp-2">{track.description || '-'}</div>
                         </TableCell>
                         <TableCell className="hidden md:table-cell text-center text-muted-foreground">
                           {track.platform || 'General'}

--- a/src/modules/leader/pages/LeaderPage.tsx
+++ b/src/modules/leader/pages/LeaderPage.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo } from "react"
-import { AlertCircle, Users2, TrendingUp, AlertTriangle, Award, Download, Zap } from "lucide-react"
+import { useState, useMemo, useEffect } from "react"
+import { AlertCircle, Users2, TrendingUp, AlertTriangle, Award, Download, Zap, LayoutGrid, List, Eye } from "lucide-react"
 import { Skeleton } from "@/shared/components/ui/skeleton"
 import { Alert, AlertDescription, AlertTitle } from "@/shared/components/ui/alert"
 import { Button } from "@/shared/components/ui/button"
@@ -9,11 +9,29 @@ import { useDataFilter } from "@/shared/hooks/useDataFilter"
 import { useGetTeamMembersQuery, useLazyExportTalentsReportQuery } from "../store/leaderApi"
 import TrainingTracksDialog from "../components/TrainingTracksDialog"
 import TeamMemberCard from "../components/TeamMemberCard"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/shared/components/ui/Table'
+import { Badge } from '@/shared/components/ui/badge'
+import { Progress } from '@/shared/components/ui/progress'
+import { getStatusConfig, formatDate } from "../utils"
 // 1. Import useToast
 import { useToast } from "@/shared/hooks/use-toast"
 
 export default function LeaderDashboard() {
   const [selectedMember, setSelectedMember] = useState<{ id: number; name: string } | null>(null)
+  const [viewMode, setViewMode] = useState<'cards' | 'table'>('cards');
+
+  useEffect(() => {
+    const saved = localStorage.getItem('leaderViewMode');
+    if (saved === 'cards' || saved === 'table') {
+      setViewMode(saved);
+    }
+  }, []);
+
+  const handleViewModeChange = (mode: 'cards' | 'table') => {
+    setViewMode(mode);
+    localStorage.setItem('leaderViewMode', mode);
+  };
+
   // 2. Initialize toast hook
   const { toast } = useToast()
 
@@ -290,9 +308,31 @@ export default function LeaderDashboard() {
           onSortToggle={toggleSortOrder}
         />
 
-        {/* Results Count */}
-        <div className="text-sm text-muted-foreground">
-          Showing {paginatedData.length} of {filteredAndSortedData.length} members
+        {/* Results Count & View Toggle */}
+        <div className="flex items-center justify-between">
+          <div className="text-sm text-muted-foreground">
+            Showing {paginatedData.length} of {filteredAndSortedData.length} members
+          </div>
+          <div className="flex items-center gap-1 bg-muted/50 p-1 rounded-md border">
+            <Button
+              variant={viewMode === 'cards' ? 'default' : 'ghost'}
+              size="sm"
+              className={`px-2 py-1 h-8 ${viewMode === 'cards' ? 'bg-primary text-primary-foreground hover:bg-primary/90' : 'text-muted-foreground'}`}
+              onClick={() => handleViewModeChange('cards')}
+              title="Cards View"
+            >
+              <LayoutGrid className="w-4 h-4" />
+            </Button>
+            <Button
+              variant={viewMode === 'table' ? 'default' : 'ghost'}
+              size="sm"
+              className={`px-2 py-1 h-8 ${viewMode === 'table' ? 'bg-primary text-primary-foreground hover:bg-primary/90' : 'text-muted-foreground'}`}
+              onClick={() => handleViewModeChange('table')}
+              title="Table View"
+            >
+              <List className="w-4 h-4" />
+            </Button>
+          </div>
         </div>
 
         {/* Team Members Cards */}
@@ -306,15 +346,86 @@ export default function LeaderDashboard() {
           </Alert>
         ) : (
           <>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {paginatedData.map((member) => (
-                <TeamMemberCard
-                  key={member.id}
-                  member={member}
-                  onViewTracks={setSelectedMember}
-                />
-              ))}
-            </div>
+            {viewMode === 'cards' ? (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 animate-in fade-in duration-300">
+                {paginatedData.map((member) => (
+                  <TeamMemberCard
+                    key={member.id}
+                    member={member}
+                    onViewTracks={setSelectedMember}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="border rounded-md animate-in fade-in duration-300">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Name</TableHead>
+                      <TableHead className="hidden md:table-cell text-center">Status</TableHead>
+                      <TableHead className="w-48 text-center">Progress</TableHead>
+                      <TableHead className="hidden lg:table-cell text-center">Courses</TableHead>
+                      <TableHead className="hidden sm:table-cell text-center">Last Activity</TableHead>
+                      <TableHead className="text-center">Action</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {paginatedData.map((member) => {
+                      const statusConfig = getStatusConfig(member.status)
+                      return (
+                        <TableRow key={member.id} className="hover:bg-muted/50">
+                          <TableCell className="font-medium">
+                            <div className="font-semibold text-base mb-0.5">{member.name}</div>
+                            <div className="text-xs text-muted-foreground">{member.email}</div>
+                            <div className="md:hidden mt-1 flex gap-2 text-xs text-muted-foreground">
+                              <span>{member.title}</span>
+                              <span>•</span>
+                              <span>{member.region}</span>
+                            </div>
+                          </TableCell>
+                          <TableCell className="hidden md:table-cell text-center">
+                            <Badge variant={statusConfig.variant} className={statusConfig.className}>
+                              {statusConfig.label}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-center">
+                            <div className="flex flex-col gap-1.5 mx-auto max-w-40">
+                              <div className="flex items-center justify-between text-xs">
+                                <span className="text-muted-foreground">Overall</span>
+                                <span className="font-medium">{member.completion_percentage}%</span>
+                              </div>
+                              <Progress value={member.completion_percentage} className="h-1.5" />
+                            </div>
+                          </TableCell>
+                          <TableCell className="hidden lg:table-cell text-center text-sm">
+                            <div className="text-muted-foreground">
+                              <span className="font-medium text-foreground">{member.completed_courses}</span> completed
+                            </div>
+                            <div className="text-muted-foreground">
+                              <span className="font-medium text-foreground">{member.active_courses}</span> active
+                            </div>
+                          </TableCell>
+                          <TableCell className="hidden sm:table-cell text-center text-sm text-muted-foreground">
+                            {formatDate(member.lastActivity)}
+                          </TableCell>
+                          <TableCell className="text-center">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => setSelectedMember({ id: member.id, name: member.name })}
+                              className="gap-2"
+                            >
+                              <Eye className="h-4 w-4" />
+                              View
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
 
             {/* Pagination Controls */}
             {totalPages > 1 && (

--- a/src/shared/components/common/CoursesDashboard.tsx
+++ b/src/shared/components/common/CoursesDashboard.tsx
@@ -1,7 +1,8 @@
-import { useMemo } from "react"
+import { useMemo, useState, useEffect } from "react"
 import StatsCard from "@/shared/components/common/StatsCard"
 import CourseCard from "@/shared/components/common/CourseCard"
-import { BookOpen, Award, TrendingUp, Monitor, Activity } from "lucide-react"
+import CourseProgressDialog from "@/shared/components/common/CourseProgressDialog"
+import { BookOpen, Award, TrendingUp, Monitor, Activity, LayoutGrid, List } from "lucide-react"
 import { useGetEnrolledCoursesQuery } from "../../store/coursesApi"
 import { Skeleton } from "@/shared/components/ui/skeleton"
 import { Alert, AlertDescription, AlertTitle } from "@/shared/components/ui/alert"
@@ -9,8 +10,26 @@ import { AlertCircle } from "lucide-react"
 import { Button } from "@/shared/components/ui/button"
 import FilterControls, { FilterConfig } from "@/shared/components/common/FilterControls"
 import { useDataFilter } from "@/shared/hooks/useDataFilter"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/shared/components/ui/Table'
+import { Badge } from '@/shared/components/ui/badge'
+import { Progress } from '@/shared/components/ui/progress'
 
 export default function TrainingTracksDashboard() {
+  const [viewMode, setViewMode] = useState<'cards' | 'table'>('cards');
+  const [selectedCourseId, setSelectedCourseId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('dashboardViewMode');
+    if (saved === 'cards' || saved === 'table') {
+      setViewMode(saved);
+    }
+  }, []);
+
+  const handleViewModeChange = (mode: 'cards' | 'table') => {
+    setViewMode(mode);
+    localStorage.setItem('dashboardViewMode', mode);
+  };
+
   // RTK Query hooks
   const { 
     data: courses, 
@@ -195,9 +214,31 @@ export default function TrainingTracksDashboard() {
         onSortToggle={toggleSortOrder}
       />
 
-      {/* Results Count */}
-      <div className="text-sm text-muted-foreground">
-        Showing {paginatedData.length} of {filteredAndSortedData.length} training tracks
+      {/* Results Count & View Toggle */}
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-muted-foreground">
+          Showing {paginatedData.length} of {filteredAndSortedData.length} training tracks
+        </div>
+        <div className="flex items-center gap-1 bg-muted/50 p-1 rounded-md border">
+          <Button
+            variant={viewMode === 'cards' ? 'default' : 'ghost'}
+            size="sm"
+            className={`px-2 py-1 h-8 ${viewMode === 'cards' ? 'bg-primary text-primary-foreground hover:bg-primary/90' : 'text-muted-foreground'}`}
+            onClick={() => handleViewModeChange('cards')}
+            title="Cards View"
+          >
+            <LayoutGrid className="w-4 h-4" />
+          </Button>
+          <Button
+            variant={viewMode === 'table' ? 'default' : 'ghost'}
+            size="sm"
+            className={`px-2 py-1 h-8 ${viewMode === 'table' ? 'bg-primary text-primary-foreground hover:bg-primary/90' : 'text-muted-foreground'}`}
+            onClick={() => handleViewModeChange('table')}
+            title="Table View"
+          >
+            <List className="w-4 h-4" />
+          </Button>
+        </div>
       </div>
 
       {/* Course Cards */}
@@ -211,23 +252,87 @@ export default function TrainingTracksDashboard() {
         </Alert>
       ) : (
         <>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {paginatedData.map((course) => (
-              <CourseCard
-                key={course.id}
-                courseId={course.id}
-                title={course.title}
-                description={course.description}
-                progress={course.progress_percentage || 0}
-                completedLessons={course.completed_courses || 0}
-                totalLessons={course.total_courses || 0}
-                platform={course.platform}
-                category={course.category}
-                duration={course.duration}
-                dueDate={course.due_date ? new Date(course.due_date) : null}
-              />
-            ))}
-          </div>
+          {viewMode === 'cards' ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 animate-in fade-in duration-300">
+              {paginatedData.map((course) => (
+                <CourseCard
+                  key={course.id}
+                  courseId={course.id}
+                  title={course.title}
+                  description={course.description}
+                  progress={course.progress_percentage || 0}
+                  completedLessons={course.completed_courses || 0}
+                  totalLessons={course.total_courses || 0}
+                  platform={course.platform}
+                  category={course.category}
+                  duration={course.duration}
+                  dueDate={course.due_date ? new Date(course.due_date) : null}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="border rounded-md animate-in fade-in duration-300">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead className="hidden md:table-cell text-center">Author</TableHead>
+                    <TableHead className="hidden sm:table-cell text-center">Category</TableHead>
+                    <TableHead className="w-48 text-center">Progress</TableHead>
+                    <TableHead className="text-center">Action</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {paginatedData.map((course) => {
+                    const progressValue = course.progress_percentage || 0;
+                    return (
+                      <TableRow key={course.id} className="hover:bg-muted/50">
+                        <TableCell className="font-medium">
+                          <div className="line-clamp-1">{course.title}</div>
+                          <div className="md:hidden text-xs text-muted-foreground mt-1 flex gap-2">
+                            <span>{course.platform || 'General'}</span>
+                            {course.category && <span>• {course.category}</span>}
+                          </div>
+                        </TableCell>
+                        <TableCell className="hidden md:table-cell text-center text-muted-foreground">
+                          {course.platform || 'General'}
+                        </TableCell>
+                        <TableCell className="hidden sm:table-cell text-center">
+                          {course.category ? (
+                            <Badge variant="outline" className="text-xs font-normal">
+                              {course.category}
+                            </Badge>
+                          ) : (
+                            <span className="text-muted-foreground">-</span>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-center">
+                          <div className="flex flex-col gap-1.5 mx-auto max-w-40">
+                            <div className="flex items-center justify-between text-xs">
+                              <span className="text-muted-foreground">
+                                {course.completed_courses || 0} / {course.total_courses || 0}
+                              </span>
+                              <span className="font-medium">{Math.round(progressValue)}%</span>
+                            </div>
+                            <Progress value={progressValue} className="h-1.5" />
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-center">
+                          <Button 
+                            size="sm" 
+                            className="bg-primary hover:bg-primary/90 text-primary-foreground font-medium"
+                            onClick={() => setSelectedCourseId(course.id)}
+                          >
+                            Continue
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )}
 
           {/* Pagination Controls */}
           {totalPages > 1 && (
@@ -263,6 +368,14 @@ export default function TrainingTracksDashboard() {
             </div>
           )}
         </>
+      )}
+
+      {selectedCourseId && (
+        <CourseProgressDialog
+          courseId={selectedCourseId}
+          open={!!selectedCourseId}
+          onOpenChange={(open) => !open && setSelectedCourseId(null)}
+        />
       )}
     </div>
   )

--- a/src/shared/components/common/CoursesDashboard.tsx
+++ b/src/shared/components/common/CoursesDashboard.tsx
@@ -276,7 +276,6 @@ export default function TrainingTracksDashboard() {
                 <TableHeader>
                   <TableRow>
                     <TableHead>Name</TableHead>
-                    <TableHead className="hidden lg:table-cell">Description</TableHead>
                     <TableHead className="hidden md:table-cell text-center">Author</TableHead>
                     <TableHead className="hidden sm:table-cell text-center">Category</TableHead>
                     <TableHead className="w-48 text-center">Progress</TableHead>
@@ -290,16 +289,10 @@ export default function TrainingTracksDashboard() {
                       <TableRow key={course.id} className="hover:bg-muted/50">
                         <TableCell className="font-medium">
                           <div className="line-clamp-1">{course.title}</div>
-                          <div className="md:hidden text-xs text-muted-foreground mt-1 space-y-1">
-                            <div className="flex gap-2">
-                              <span>{course.platform || 'General'}</span>
-                              {course.category && <span>• {course.category}</span>}
-                            </div>
-                            <div className="line-clamp-1 italic">{course.description}</div>
+                          <div className="md:hidden text-xs text-muted-foreground mt-1 flex gap-2">
+                            <span>{course.platform || 'General'}</span>
+                            {course.category && <span>• {course.category}</span>}
                           </div>
-                        </TableCell>
-                        <TableCell className="hidden lg:table-cell text-muted-foreground text-sm max-w-sm">
-                          <div className="line-clamp-2">{course.description || '-'}</div>
                         </TableCell>
                         <TableCell className="hidden md:table-cell text-center text-muted-foreground">
                           {course.platform || 'General'}

--- a/src/shared/components/common/CoursesDashboard.tsx
+++ b/src/shared/components/common/CoursesDashboard.tsx
@@ -276,6 +276,7 @@ export default function TrainingTracksDashboard() {
                 <TableHeader>
                   <TableRow>
                     <TableHead>Name</TableHead>
+                    <TableHead className="hidden lg:table-cell">Description</TableHead>
                     <TableHead className="hidden md:table-cell text-center">Author</TableHead>
                     <TableHead className="hidden sm:table-cell text-center">Category</TableHead>
                     <TableHead className="w-48 text-center">Progress</TableHead>
@@ -289,10 +290,16 @@ export default function TrainingTracksDashboard() {
                       <TableRow key={course.id} className="hover:bg-muted/50">
                         <TableCell className="font-medium">
                           <div className="line-clamp-1">{course.title}</div>
-                          <div className="md:hidden text-xs text-muted-foreground mt-1 flex gap-2">
-                            <span>{course.platform || 'General'}</span>
-                            {course.category && <span>• {course.category}</span>}
+                          <div className="md:hidden text-xs text-muted-foreground mt-1 space-y-1">
+                            <div className="flex gap-2">
+                              <span>{course.platform || 'General'}</span>
+                              {course.category && <span>• {course.category}</span>}
+                            </div>
+                            <div className="line-clamp-1 italic">{course.description}</div>
                           </div>
+                        </TableCell>
+                        <TableCell className="hidden lg:table-cell text-muted-foreground text-sm max-w-sm">
+                          <div className="line-clamp-2">{course.description || '-'}</div>
                         </TableCell>
                         <TableCell className="hidden md:table-cell text-center text-muted-foreground">
                           {course.platform || 'General'}


### PR DESCRIPTION
🚀 Description
This PR introduces a new toggle feature that allows users to seamlessly switch between a Card (Grid) view and a Table (List) view across the main dashboard and catalog pages. The selection is persisted locally for a better user experience.

🛠️ Changes Made
View Toggle Component: Added segmented control buttons (LayoutGrid and List icons) next to the results counter across all primary views.
Table Implementations: Replicated the data structure of the existing cards into responsive table layouts for:
CatalogPage: Displays training tracks, author, category, total courses, and an inline "Enroll" button.
CoursesDashboard: Displays active tracks with centered progress bars, author, category, and a "Continue" button triggering the progress dialog.
LeaderPage: Displays team members, their overall progress, performance status badges, last activity, and a quick "View" action.
State Persistence: Integrated localStorage (catalogViewMode, dashboardViewMode, leaderViewMode) to remember the user's preferred view across sessions.
UI/UX Polish:
Smooth fade-in transitions (animate-in fade-in duration-300) between view states.
Centered alignment on secondary table columns (Author, Category, Progress, Action) for cleaner aesthetics.
Responsive table design (condensing secondary data into primary columns on mobile screens).
📁 Files Modified
src/modules/consultant/pages/CatalogPage.tsx
src/shared/components/common/CoursesDashboard.tsx
src/modules/leader/pages/LeaderPage.tsx
🧪 How to Test
Navigate to the Training Catalog.
Click the new Table icon next to the "Showing X of X" text. Ensure the view switches to a table and the columns are aligned properly.
Reload the page. Verify the view remains as a Table.
Test the "Enroll" button from the Table view.
Repeat the toggle and action verification for the My Learning (Courses Dashboard) (testing the "Continue" dialog) and the Leader Dashboard (testing the "View" dialog).