### PR TITLE
Feature roadmap

### DIFF
--- a/src/modules/consultant/components/RoadmapTimeline.tsx
+++ b/src/modules/consultant/components/RoadmapTimeline.tsx
@@ -1,35 +1,36 @@
+import { useState } from 'react';
 import { Card, CardContent } from '@/shared/components/ui/card';
 import { Badge } from '@/shared/components/ui/badge';
 import { Button } from '@/shared/components/ui/button';
-import { Loader2, CheckCircle2, BookOpen, Clock } from 'lucide-react';
+import { Loader2, CheckCircle2, BookOpen, Clock, ChevronDown, ChevronUp } from 'lucide-react';
 import type { Roadmap, TrainingTrack } from '@/shared/store/coursesApi';
 
 interface RoadmapTimelineProps {
   roadmap: Roadmap;
   enrolledIds: Set<string>;
-  isEnrolling: boolean;
   isEnrollingRoadmap: boolean;
   onSelectTrack: (track: TrainingTrack) => void;
-  onEnroll: (trackId: string) => void;
   onEnrollRoadmap: (roadmap: Roadmap) => void;
 }
 
 export default function RoadmapTimeline({
   roadmap,
   enrolledIds,
-  isEnrolling,
   isEnrollingRoadmap,
   onSelectTrack,
-  onEnroll,
   onEnrollRoadmap,
 }: RoadmapTimelineProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
   const tracks = roadmap.training_tracks ?? [];
   const enrolledCount = tracks.filter((t) => enrolledIds.has(String(t.id))).length;
   const allEnrolled = tracks.length > 0 && enrolledCount === tracks.length;
 
   return (
     <Card className="overflow-hidden">
-      <div className="border-b bg-gradient-to-r from-primary/5 via-primary/10 to-transparent p-6">
+      <div
+        className="border-b bg-gradient-to-r from-primary/5 via-primary/10 to-transparent p-6 cursor-pointer select-none"
+        onClick={() => setIsExpanded((prev) => !prev)}
+      >
         <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2 mb-2">
@@ -46,9 +47,15 @@ export default function RoadmapTimeline({
             )}
           </div>
 
-          <div className="flex-shrink-0 sm:pt-1">
+          <div className="flex items-center gap-2 flex-shrink-0 sm:pt-1">
             {allEnrolled ? (
-              <Button variant="outline" size="sm" disabled className="gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled
+                className="gap-2"
+                onClick={(e) => e.stopPropagation()}
+              >
                 <CheckCircle2 className="w-4 h-4" />
                 Enrolled
               </Button>
@@ -56,7 +63,10 @@ export default function RoadmapTimeline({
               <Button
                 size="sm"
                 className="bg-primary hover:bg-primary/90"
-                onClick={() => onEnrollRoadmap(roadmap)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEnrollRoadmap(roadmap);
+                }}
                 disabled={isEnrollingRoadmap || tracks.length === 0}
               >
                 {isEnrollingRoadmap ? (
@@ -69,18 +79,30 @@ export default function RoadmapTimeline({
                 )}
               </Button>
             )}
+            <button
+              aria-label={isExpanded ? 'Collapse roadmap' : 'Expand roadmap'}
+              aria-expanded={isExpanded}
+              className="p-1.5 rounded-md hover:bg-muted transition-colors text-muted-foreground"
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsExpanded((prev) => !prev);
+              }}
+            >
+              {isExpanded ? <ChevronUp className="w-5 h-5" /> : <ChevronDown className="w-5 h-5" />}
+            </button>
           </div>
         </div>
       </div>
 
-      <CardContent className="p-0">
-        {tracks.length === 0 ? (
-          <div className="p-8 text-center text-sm text-muted-foreground italic">
-            This roadmap has no training tracks yet.
-          </div>
-        ) : (
-          <ol className="relative px-4 sm:px-8 py-6">
-            {tracks.map((track, index) => {
+      {isExpanded && (
+        <CardContent className="p-0">
+          {tracks.length === 0 ? (
+            <div className="p-8 text-center text-sm text-muted-foreground italic">
+              This roadmap has no training tracks yet.
+            </div>
+          ) : (
+            <ol className="relative px-4 sm:px-8 py-6">
+              {tracks.map((track, index) => {
               const isEnrolled = enrolledIds.has(String(track.id));
               const isLast = index === tracks.length - 1;
               const stepNumber = index + 1;
@@ -159,29 +181,14 @@ export default function RoadmapTimeline({
                           </div>
                         </div>
 
-                        <div className="flex-shrink-0 sm:w-32">
-                          {isEnrolled ? (
-                            <Button variant="outline" size="sm" className="w-full" disabled>
+                        {isEnrolled && (
+                          <div className="flex-shrink-0">
+                            <Badge variant="outline" className="gap-1 text-xs text-primary border-primary/40">
+                              <CheckCircle2 className="w-3 h-3" />
                               Enrolled
-                            </Button>
-                          ) : (
-                            <Button
-                              size="sm"
-                              className="w-full bg-primary hover:bg-primary/90"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                onEnroll(track.id);
-                              }}
-                              disabled={isEnrolling}
-                            >
-                              {isEnrolling ? (
-                                <Loader2 className="h-4 w-4 animate-spin" />
-                              ) : (
-                                'Enroll'
-                              )}
-                            </Button>
-                          )}
-                        </div>
+                            </Badge>
+                          </div>
+                        )}
                       </div>
                     </div>
                   </div>
@@ -191,6 +198,7 @@ export default function RoadmapTimeline({
           </ol>
         )}
       </CardContent>
+      )}
     </Card>
   );
 }

--- a/src/modules/consultant/components/RoadmapsTab.tsx
+++ b/src/modules/consultant/components/RoadmapsTab.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import {
   useGetAllRoadmapsQuery,
   useGetAllCoursesQuery,
@@ -9,7 +9,7 @@ import {
 import { Button } from '@/shared/components/ui/button';
 import { Badge } from '@/shared/components/ui/badge';
 import { toast } from 'sonner';
-import { Loader2, AlertCircle, BookOpen, Search } from 'lucide-react';
+import { Loader2, AlertCircle, BookOpen, Monitor, LayoutGrid, List, CheckCircle2 } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/shared/components/ui/alert';
 import {
   Dialog,
@@ -17,10 +17,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/shared/components/ui/dialog';
-import { Input } from '@/shared/components/ui/Input';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/shared/components/ui/Table';
 import { TrainingTrack, Roadmap } from '@/shared/store/coursesApi';
 import ExpandableText from '@/shared/components/common/ExpandableText';
 import RoadmapTimeline from './RoadmapTimeline';
+import FilterControls, { FilterConfig } from '@/shared/components/common/FilterControls';
+
+const ITEMS_PER_PAGE = 5;
 
 export default function RoadmapsTab() {
   const {
@@ -32,18 +35,30 @@ export default function RoadmapsTab() {
   const { data: enrolledTracks = [], isLoading: isLoadingEnrolled } =
     useGetEnrolledCoursesQuery();
   const { data: allTracks = [] } = useGetAllCoursesQuery();
-  const [enrollInCourse, { isLoading: isEnrolling }] = useEnrollInCourseMutation();
+  const [enrollInCourse] = useEnrollInCourseMutation();
   const [selectedTrack, setSelectedTrack] = useState<TrainingTrack | null>(null);
-  const [searchTerm, setSearchTerm] = useState('');
   const [enrollingRoadmapId, setEnrollingRoadmapId] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [viewMode, setViewMode] = useState<'cards' | 'table'>('cards');
 
-  // Hydrate tracks from the catalog list when the roadmaps endpoint
-  // returns tracks with only ids (or partial data).
+  // Filter state
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filters, setFilters] = useState<Record<string, string>>({});
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+
+  useEffect(() => {
+    const saved = localStorage.getItem('roadmapsViewMode');
+    if (saved === 'cards' || saved === 'table') setViewMode(saved);
+  }, []);
+
+  const handleViewModeChange = (mode: 'cards' | 'table') => {
+    setViewMode(mode);
+    localStorage.setItem('roadmapsViewMode', mode);
+  };
+
   const roadmaps = useMemo(() => {
     if (!rawRoadmaps) return [];
-
     const trackById = new Map(allTracks.map((t) => [String(t.id), t]));
-
     return rawRoadmaps.map((r) => ({
       ...r,
       training_tracks: r.training_tracks.map((t) => {
@@ -64,17 +79,43 @@ export default function RoadmapsTab() {
     }));
   }, [rawRoadmaps, allTracks]);
 
-  // Normalize ids to strings so they match the roadmap transform output,
-  // and include any track flagged as enrolled in the catalog list (covers
-  // assignments inherited via the user's job title).
   const enrolledIds = useMemo(() => {
     const ids = new Set<string>();
     enrolledTracks.forEach((t) => ids.add(String(t.id)));
-    allTracks.forEach((t) => {
-      if (t.enrolled) ids.add(String(t.id));
-    });
     return ids;
-  }, [enrolledTracks, allTracks]);
+  }, [enrolledTracks]);
+
+  // Extract unique categories and platforms from all tracks across all roadmaps
+  const { categories, platforms } = useMemo(() => {
+    const cats = new Set<string>();
+    const plats = new Set<string>();
+    roadmaps.forEach((r) =>
+      r.training_tracks.forEach((t) => {
+        if (t.category) cats.add(t.category);
+        if (t.platform) plats.add(t.platform);
+      })
+    );
+    return {
+      categories: Array.from(cats).sort(),
+      platforms: Array.from(plats).sort(),
+    };
+  }, [roadmaps]);
+
+  const filterConfigs: FilterConfig[] = [
+    {
+      key: 'category',
+      label: 'Category',
+      placeholder: 'All Categories',
+      options: categories.map((c) => ({ value: c, label: c })),
+    },
+    {
+      key: 'platform',
+      label: 'Platform',
+      placeholder: 'All Platforms',
+      icon: Monitor,
+      options: platforms.map((p) => ({ value: p, label: p })),
+    },
+  ];
 
   const { data: trackDetails, isFetching: isFetchingDetails } = useGetCourseDetailsQuery(
     selectedTrack?.id ?? '',
@@ -102,20 +143,6 @@ export default function RoadmapsTab() {
     return selectedTrack;
   }, [trackDetails, selectedTrack]);
 
-  const handleEnroll = async (trackId: string) => {
-    try {
-      await enrollInCourse(trackId).unwrap();
-      toast.success('Successfully enrolled!');
-      refetchRoadmaps();
-    } catch (error: any) {
-      if (error?.status === 400) {
-        toast.error('You are already enrolled in this track via your job title.');
-      } else {
-        toast.error('Failed to enroll. Please try again.');
-      }
-    }
-  };
-
   const handleEnrollRoadmap = async (roadmap: Roadmap) => {
     const pending = roadmap.training_tracks.filter((t) => !enrolledIds.has(String(t.id)));
     if (pending.length === 0) return;
@@ -128,41 +155,81 @@ export default function RoadmapsTab() {
 
     const failed = results.filter((r) => r.status === 'rejected').length;
     const succeeded = pending.length - failed;
-
-    if (succeeded > 0) {
-      toast.success(
-        `Enrolled in ${succeeded} ${succeeded === 1 ? 'track' : 'tracks'} of "${roadmap.name}".`
-      );
-    }
-    if (failed > 0) {
-      toast.error(
-        `${failed} ${failed === 1 ? 'track' : 'tracks'} could not be enrolled.`
-      );
-    }
+    if (succeeded > 0)
+      toast.success(`Enrolled in ${succeeded} ${succeeded === 1 ? 'track' : 'tracks'} of "${roadmap.name}".`);
+    if (failed > 0)
+      toast.error(`${failed} ${failed === 1 ? 'track' : 'tracks'} could not be enrolled.`);
     refetchRoadmaps();
   };
 
+  const updateFilter = (key: string, value: string) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+    setCurrentPage(1);
+  };
+
   const filteredRoadmaps = useMemo(() => {
-    if (!searchTerm.trim()) return roadmaps;
-    const q = searchTerm.toLowerCase();
-    return roadmaps
+    const q = searchTerm.trim().toLowerCase();
+    const categoryFilter = filters.category && filters.category !== 'all' ? filters.category : null;
+    const platformFilter = filters.platform && filters.platform !== 'all' ? filters.platform : null;
+
+    let result = roadmaps
       .map((r) => {
+        // Apply category / platform filters at track level
+        const tracksAfterFilter = r.training_tracks.filter((t) => {
+          const matchCat = !categoryFilter || t.category === categoryFilter;
+          const matchPlat = !platformFilter || t.platform === platformFilter;
+          return matchCat && matchPlat;
+        });
+
+        // If both category and platform filters are active and no tracks match, drop the roadmap
+        if ((categoryFilter || platformFilter) && tracksAfterFilter.length === 0) return null;
+
+        const baseRoadmap = (categoryFilter || platformFilter)
+          ? { ...r, training_tracks: tracksAfterFilter }
+          : r;
+
+        // Apply search
+        if (!q) return baseRoadmap;
+
         const matchesRoadmap =
-          r.name.toLowerCase().includes(q) ||
-          (r.description ?? '').toLowerCase().includes(q);
-        const matchingTracks = r.training_tracks.filter(
+          baseRoadmap.name.toLowerCase().includes(q) ||
+          (baseRoadmap.description ?? '').toLowerCase().includes(q);
+
+        const matchingTracks = baseRoadmap.training_tracks.filter(
           (t) =>
             t.title.toLowerCase().includes(q) ||
             (t.description ?? '').toLowerCase().includes(q) ||
             (t.platform ?? '').toLowerCase().includes(q) ||
             (t.category ?? '').toLowerCase().includes(q)
         );
-        if (matchesRoadmap) return r;
-        if (matchingTracks.length > 0) return { ...r, training_tracks: matchingTracks };
+
+        if (matchesRoadmap) return baseRoadmap;
+        if (matchingTracks.length > 0) return { ...baseRoadmap, training_tracks: matchingTracks };
         return null;
       })
       .filter((r): r is NonNullable<typeof r> => r !== null);
-  }, [roadmaps, searchTerm]);
+
+    // Sort by name
+    result = [...result].sort((a, b) =>
+      sortOrder === 'asc'
+        ? a.name.localeCompare(b.name)
+        : b.name.localeCompare(a.name)
+    );
+
+    return result;
+  }, [roadmaps, searchTerm, filters, sortOrder]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredRoadmaps.length / ITEMS_PER_PAGE));
+  const safePage = Math.min(currentPage, totalPages);
+  const paginatedRoadmaps = filteredRoadmaps.slice(
+    (safePage - 1) * ITEMS_PER_PAGE,
+    safePage * ITEMS_PER_PAGE
+  );
+
+  const handleSearchChange = (value: string) => {
+    setSearchTerm(value);
+    setCurrentPage(1);
+  };
 
   if (isLoadingRoadmaps || isLoadingEnrolled) {
     return (
@@ -178,9 +245,7 @@ export default function RoadmapsTab() {
       <Alert variant="destructive">
         <AlertCircle className="h-4 w-4" />
         <AlertTitle>Error</AlertTitle>
-        <AlertDescription>
-          Unable to load roadmaps. Please try again later.
-        </AlertDescription>
+        <AlertDescription>Unable to load roadmaps. Please try again later.</AlertDescription>
       </Alert>
     );
   }
@@ -194,18 +259,44 @@ export default function RoadmapsTab() {
         </p>
       </div>
 
-      <div className="relative max-w-md">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-        <Input
-          placeholder="Search roadmaps, tracks, categories..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          className="pl-9"
-        />
-      </div>
+      <FilterControls
+        searchValue={searchTerm}
+        onSearchChange={handleSearchChange}
+        searchPlaceholder="Search roadmaps, tracks, categories..."
+        filters={filterConfigs}
+        filterValues={filters}
+        onFilterChange={updateFilter}
+        sortOrder={sortOrder}
+        onSortToggle={() => {
+          setSortOrder((o) => (o === 'asc' ? 'desc' : 'asc'));
+          setCurrentPage(1);
+        }}
+      />
 
-      <div className="text-sm text-muted-foreground">
-        Showing {filteredRoadmaps.length} of {roadmaps.length} roadmaps
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-muted-foreground">
+          Showing {paginatedRoadmaps.length} of {filteredRoadmaps.length} roadmaps
+        </div>
+        <div className="flex items-center gap-1 bg-muted/50 p-1 rounded-md border">
+          <Button
+            variant={viewMode === 'cards' ? 'default' : 'ghost'}
+            size="sm"
+            className={`px-2 py-1 h-8 ${viewMode === 'cards' ? 'bg-primary text-primary-foreground hover:bg-primary/90' : 'text-muted-foreground'}`}
+            onClick={() => handleViewModeChange('cards')}
+            title="Cards View"
+          >
+            <LayoutGrid className="w-4 h-4" />
+          </Button>
+          <Button
+            variant={viewMode === 'table' ? 'default' : 'ghost'}
+            size="sm"
+            className={`px-2 py-1 h-8 ${viewMode === 'table' ? 'bg-primary text-primary-foreground hover:bg-primary/90' : 'text-muted-foreground'}`}
+            onClick={() => handleViewModeChange('table')}
+            title="Table View"
+          >
+            <List className="w-4 h-4" />
+          </Button>
+        </div>
       </div>
 
       {filteredRoadmaps.length === 0 ? (
@@ -213,30 +304,133 @@ export default function RoadmapsTab() {
           <AlertCircle className="h-4 w-4" />
           <AlertTitle>No roadmaps found</AlertTitle>
           <AlertDescription>
-            Try adjusting your search to find what you're looking for.
+            Try adjusting your search or filters to find what you're looking for.
           </AlertDescription>
         </Alert>
       ) : (
-        <div className="space-y-8 animate-in fade-in duration-300">
-          {filteredRoadmaps.map((roadmap) => (
-            <RoadmapTimeline
-              key={roadmap.id}
-              roadmap={roadmap}
-              enrolledIds={enrolledIds}
-              isEnrolling={isEnrolling}
-              isEnrollingRoadmap={enrollingRoadmapId === roadmap.id}
-              onSelectTrack={setSelectedTrack}
-              onEnroll={handleEnroll}
-              onEnrollRoadmap={handleEnrollRoadmap}
-            />
-          ))}
-        </div>
+        <>
+          {viewMode === 'cards' ? (
+            <div className="space-y-8 animate-in fade-in duration-300">
+              {paginatedRoadmaps.map((roadmap) => (
+                <RoadmapTimeline
+                  key={roadmap.id}
+                  roadmap={roadmap}
+                  enrolledIds={enrolledIds}
+                  isEnrollingRoadmap={enrollingRoadmapId === roadmap.id}
+                  onSelectTrack={setSelectedTrack}
+                  onEnrollRoadmap={handleEnrollRoadmap}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="border rounded-md animate-in fade-in duration-300">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead className="hidden lg:table-cell">Description</TableHead>
+                    <TableHead className="text-center">Tracks</TableHead>
+                    <TableHead className="text-center">Enrolled</TableHead>
+                    <TableHead className="text-center">Action</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {paginatedRoadmaps.map((roadmap) => {
+                    const tracks = roadmap.training_tracks ?? [];
+                    const enrolledCount = tracks.filter((t) => enrolledIds.has(String(t.id))).length;
+                    const allEnrolled = tracks.length > 0 && enrolledCount === tracks.length;
+                    const isEnrollingThis = enrollingRoadmapId === roadmap.id;
+
+                    return (
+                      <TableRow key={roadmap.id}>
+                        <TableCell className="font-medium max-w-[200px]">
+                          <div className="line-clamp-1">{roadmap.name}</div>
+                          <div className="md:hidden text-xs text-muted-foreground mt-1 line-clamp-1 italic">
+                            {roadmap.description}
+                          </div>
+                        </TableCell>
+                        <TableCell className="hidden lg:table-cell text-muted-foreground text-sm max-w-[400px]">
+                          <div className="line-clamp-2 leading-relaxed">
+                            {roadmap.description || '-'}
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-center text-muted-foreground">
+                          {tracks.length}
+                        </TableCell>
+                        <TableCell className="text-center">
+                          {allEnrolled ? (
+                            <Badge variant="outline" className="gap-1 text-xs text-primary border-primary/40">
+                              <CheckCircle2 className="w-3 h-3" />
+                              All enrolled
+                            </Badge>
+                          ) : (
+                            <span className="text-sm text-muted-foreground">
+                              {enrolledCount}/{tracks.length}
+                            </span>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-center">
+                          {allEnrolled ? (
+                            <Button variant="outline" size="sm" disabled>
+                              Enrolled
+                            </Button>
+                          ) : (
+                            <Button
+                              size="sm"
+                              className="bg-primary hover:bg-primary/90"
+                              onClick={() => handleEnrollRoadmap(roadmap)}
+                              disabled={isEnrollingThis || tracks.length === 0}
+                            >
+                              {isEnrollingThis ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                'Enroll'
+                              )}
+                            </Button>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+
+          {totalPages > 1 && (
+            <div className="flex justify-center items-center gap-2 mt-6">
+              <Button
+                variant="muted"
+                onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                disabled={safePage === 1}
+              >
+                Previous
+              </Button>
+              <div className="flex gap-1">
+                {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+                  <Button
+                    key={page}
+                    variant={safePage === page ? 'default' : 'muted'}
+                    onClick={() => setCurrentPage(page)}
+                    className="min-w-10 px-3"
+                  >
+                    {page}
+                  </Button>
+                ))}
+              </div>
+              <Button
+                variant="muted"
+                onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                disabled={safePage === totalPages}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
       )}
 
-      <Dialog
-        open={!!selectedTrack}
-        onOpenChange={(open) => !open && setSelectedTrack(null)}
-      >
+      <Dialog open={!!selectedTrack} onOpenChange={(open) => !open && setSelectedTrack(null)}>
         <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
           {displayTrack && (
             <>
@@ -274,27 +468,19 @@ export default function RoadmapsTab() {
                   {isFetchingDetails ? (
                     <div className="flex flex-col items-center justify-center py-12 space-y-3 bg-gray-50/50">
                       <Loader2 className="h-8 w-8 animate-spin text-primary" />
-                      <p className="text-sm text-muted-foreground animate-pulse">
-                        Loading courses...
-                      </p>
+                      <p className="text-sm text-muted-foreground animate-pulse">Loading courses...</p>
                     </div>
                   ) : displayTrack?.courses && displayTrack.courses.length > 0 ? (
                     <div className="divide-y divide-gray-200">
                       {displayTrack.courses.map((course, index) => (
-                        <div
-                          key={course.id || index}
-                          className="p-4 flex items-start gap-4 bg-gray-50/80"
-                        >
+                        <div key={course.id || index} className="p-4 flex items-start gap-4 bg-gray-50/80">
                           <span className="flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-full bg-white border border-gray-200 text-gray-600 text-xs font-bold mt-0.5">
                             {index + 1}
                           </span>
                           <div className="space-y-0.5">
                             <p className="font-semibold text-gray-900">{course.title}</p>
                             {course.description && (
-                              <ExpandableText
-                                text={course.description}
-                                className="text-sm text-gray-600 mt-0.5"
-                              />
+                              <ExpandableText text={course.description} className="text-sm text-gray-600 mt-0.5" />
                             )}
                             {course.duration && (
                               <p className="text-xs text-gray-500 flex items-center gap-1 mt-1">
@@ -311,21 +497,6 @@ export default function RoadmapsTab() {
                     </div>
                   )}
                 </div>
-
-                {!enrolledIds.has(String(displayTrack.id)) && (
-                  <div className="flex justify-end pt-2">
-                    <Button
-                      onClick={() => {
-                        handleEnroll(displayTrack.id);
-                        setSelectedTrack(null);
-                      }}
-                      disabled={isEnrolling}
-                      className="w-full sm:w-auto"
-                    >
-                      Enroll Now
-                    </Button>
-                  </div>
-                )}
               </div>
             </>
           )}

--- a/src/modules/consultant/components/RoadmapsTab.tsx
+++ b/src/modules/consultant/components/RoadmapsTab.tsx
@@ -3,7 +3,7 @@ import {
   useGetAllRoadmapsQuery,
   useGetAllCoursesQuery,
   useGetEnrolledCoursesQuery,
-  useEnrollInCourseMutation,
+  useEnrollInRoadmapMutation,
   useGetCourseDetailsQuery,
 } from '@/shared/store/coursesApi';
 import { Button } from '@/shared/components/ui/button';
@@ -35,7 +35,7 @@ export default function RoadmapsTab() {
   const { data: enrolledTracks = [], isLoading: isLoadingEnrolled } =
     useGetEnrolledCoursesQuery();
   const { data: allTracks = [] } = useGetAllCoursesQuery();
-  const [enrollInCourse] = useEnrollInCourseMutation();
+  const [enrollInRoadmap] = useEnrollInRoadmapMutation();
   const [selectedTrack, setSelectedTrack] = useState<TrainingTrack | null>(null);
   const [enrollingRoadmapId, setEnrollingRoadmapId] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
@@ -144,22 +144,17 @@ export default function RoadmapsTab() {
   }, [trackDetails, selectedTrack]);
 
   const handleEnrollRoadmap = async (roadmap: Roadmap) => {
-    const pending = roadmap.training_tracks.filter((t) => !enrolledIds.has(String(t.id)));
-    if (pending.length === 0) return;
-
     setEnrollingRoadmapId(roadmap.id);
-    const results = await Promise.allSettled(
-      pending.map((t) => enrollInCourse(t.id).unwrap())
-    );
-    setEnrollingRoadmapId(null);
-
-    const failed = results.filter((r) => r.status === 'rejected').length;
-    const succeeded = pending.length - failed;
-    if (succeeded > 0)
-      toast.success(`Enrolled in ${succeeded} ${succeeded === 1 ? 'track' : 'tracks'} of "${roadmap.name}".`);
-    if (failed > 0)
-      toast.error(`${failed} ${failed === 1 ? 'track' : 'tracks'} could not be enrolled.`);
-    refetchRoadmaps();
+    try {
+      await enrollInRoadmap(roadmap.id).unwrap();
+      toast.success(`Enrolled in roadmap "${roadmap.name}".`);
+      refetchRoadmaps();
+    } catch (error: any) {
+      const message = error?.data?.error || error?.data?.message;
+      toast.error(message || 'Failed to enroll in roadmap. Please try again.');
+    } finally {
+      setEnrollingRoadmapId(null);
+    }
   };
 
   const updateFilter = (key: string, value: string) => {

--- a/src/modules/consultant/components/TrainingCatalogTab.tsx
+++ b/src/modules/consultant/components/TrainingCatalogTab.tsx
@@ -87,8 +87,9 @@ export default function TrainingCatalogTab() {
       toast.success('Successfully enrolled!');
       refetchCatalog();
     } catch (error: any) {
-      if (error?.status === 400) {
-        toast.error('You are already enrolled in this track via your job title.');
+      const message = error?.data?.error || error?.data?.message;
+      if (message) {
+        toast.error(message);
       } else {
         toast.error('Failed to enroll. Please try again.');
       }

--- a/src/modules/consultant/pages/CatalogPage.tsx
+++ b/src/modules/consultant/pages/CatalogPage.tsx
@@ -28,12 +28,18 @@ export default function CatalogPage() {
   return (
     <div className="container mx-auto p-6 space-y-6 max-w-7xl">
       <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-6">
-        <TabsList className="grid grid-cols-2 w-full max-w-md h-auto">
-          <TabsTrigger value="catalog" className="gap-2 py-2">
+        <TabsList className="h-auto w-full justify-start rounded-none border-b bg-transparent p-0 gap-0">
+          <TabsTrigger
+            value="catalog"
+            className="gap-2 rounded-none border-b-2 border-transparent px-4 py-3 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none data-[state=active]:text-primary font-medium"
+          >
             <Search className="w-4 h-4" />
             Training Catalog
           </TabsTrigger>
-          <TabsTrigger value="roadmaps" className="gap-2 py-2">
+          <TabsTrigger
+            value="roadmaps"
+            className="gap-2 rounded-none border-b-2 border-transparent px-4 py-3 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none data-[state=active]:text-primary font-medium"
+          >
             <RouteIcon className="w-4 h-4" />
             Roadmaps
           </TabsTrigger>

--- a/src/shared/components/common/MyProgressRoadmapView.tsx
+++ b/src/shared/components/common/MyProgressRoadmapView.tsx
@@ -1,10 +1,10 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Card, CardContent } from '@/shared/components/ui/card';
 import { Badge } from '@/shared/components/ui/badge';
 import { Button } from '@/shared/components/ui/button';
 import { Progress } from '@/shared/components/ui/progress';
 import { Alert, AlertDescription, AlertTitle } from '@/shared/components/ui/alert';
-import { AlertCircle, CheckCircle2, BookOpen, Clock, Lock, Loader2 } from 'lucide-react';
+import { AlertCircle, CheckCircle2, BookOpen, Clock, Lock, Loader2, ChevronDown, ChevronUp } from 'lucide-react';
 import {
   useGetAllRoadmapsQuery,
   TrainingTrack,
@@ -20,6 +20,7 @@ export default function MyProgressRoadmapView({
   onSelectCourse,
 }: MyProgressRoadmapViewProps) {
   const { data: rawRoadmaps, isLoading } = useGetAllRoadmapsQuery();
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
 
   const roadmaps = useMemo(() => rawRoadmaps ?? [], [rawRoadmaps]);
 
@@ -29,12 +30,20 @@ export default function MyProgressRoadmapView({
     return map;
   }, [courses]);
 
-  // Keep only roadmaps where the user has at least one enrolled track.
   const visibleRoadmaps = useMemo(() => {
     return roadmaps.filter((r) =>
       r.training_tracks.some((t) => enrolledById.has(String(t.id)))
     );
   }, [roadmaps, enrolledById]);
+
+  const toggleCollapsed = (id: string) => {
+    setCollapsedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
 
   if (isLoading) {
     return (
@@ -61,6 +70,8 @@ export default function MyProgressRoadmapView({
   return (
     <div className="space-y-8 animate-in fade-in duration-300">
       {visibleRoadmaps.map((roadmap) => {
+        const isCollapsed = collapsedIds.has(roadmap.id);
+
         const enrolledTracks = roadmap.training_tracks.filter((t) =>
           enrolledById.has(String(t.id))
         );
@@ -80,177 +91,206 @@ export default function MyProgressRoadmapView({
 
         return (
           <Card key={roadmap.id} className="overflow-hidden">
-            <div className="border-b bg-gradient-to-r from-primary/5 via-primary/10 to-transparent p-6">
-              <div className="flex items-center gap-2 mb-2">
-                <Badge variant="outline" className="text-xs uppercase tracking-wide">
-                  Roadmap
-                </Badge>
-                <span className="text-xs text-muted-foreground">
-                  {completedCount}/{enrolledTracks.length} completed
-                </span>
-              </div>
-              <h2 className="text-2xl font-bold tracking-tight">{roadmap.name}</h2>
-              {roadmap.description && (
-                <p className="text-muted-foreground mt-1 max-w-3xl">
-                  {roadmap.description}
-                </p>
-              )}
-              <div className="mt-4 max-w-md">
-                <div className="flex items-center justify-between text-xs mb-1">
-                  <span className="text-muted-foreground">Overall progress</span>
-                  <span className="font-medium">{roadmapProgress}%</span>
+            {/* Header — clickable to collapse/expand */}
+            <div
+              className="border-b bg-gradient-to-r from-primary/5 via-primary/10 to-transparent p-6 cursor-pointer select-none"
+              onClick={() => toggleCollapsed(roadmap.id)}
+            >
+              <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Badge variant="outline" className="text-xs uppercase tracking-wide">
+                      Roadmap
+                    </Badge>
+                    <span className="text-xs text-muted-foreground">
+                      {completedCount}/{enrolledTracks.length} completed
+                    </span>
+                  </div>
+                  <h2 className="text-2xl font-bold tracking-tight">{roadmap.name}</h2>
+                  {roadmap.description && (
+                    <p className="text-muted-foreground mt-1 max-w-3xl">
+                      {roadmap.description}
+                    </p>
+                  )}
+                  <div className="mt-4 max-w-md">
+                    <div className="flex items-center justify-between text-xs mb-1">
+                      <span className="text-muted-foreground">Overall progress</span>
+                      <span className="font-medium">{roadmapProgress}%</span>
+                    </div>
+                    <Progress value={roadmapProgress} className="h-2" />
+                  </div>
                 </div>
-                <Progress value={roadmapProgress} className="h-2" />
+
+                <button
+                  aria-label={isCollapsed ? 'Expand roadmap' : 'Collapse roadmap'}
+                  aria-expanded={!isCollapsed}
+                  className="self-start p-1.5 rounded-md hover:bg-muted transition-colors text-muted-foreground flex-shrink-0 sm:mt-1"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleCollapsed(roadmap.id);
+                  }}
+                >
+                  {isCollapsed ? (
+                    <ChevronDown className="w-5 h-5" />
+                  ) : (
+                    <ChevronUp className="w-5 h-5" />
+                  )}
+                </button>
               </div>
             </div>
 
-            <CardContent className="p-0">
-              <ol className="relative px-4 sm:px-8 py-6">
-                {roadmap.training_tracks.map((track, index) => {
-                  const enrolled = enrolledById.get(String(track.id));
-                  const isEnrolled = !!enrolled;
-                  const progressValue = enrolled?.progress_percentage ?? 0;
-                  const isCompleted = progressValue === 100;
-                  const isLast = index === roadmap.training_tracks.length - 1;
-                  const stepNumber = index + 1;
+            {!isCollapsed && (
+              <CardContent className="p-0">
+                <ol className="relative px-4 sm:px-8 py-6">
+                  {roadmap.training_tracks.map((track, index) => {
+                    const enrolled = enrolledById.get(String(track.id));
+                    const isEnrolled = !!enrolled;
+                    const progressValue = enrolled?.progress_percentage ?? 0;
+                    const isCompleted = progressValue === 100;
+                    const isLast = index === roadmap.training_tracks.length - 1;
+                    const stepNumber = index + 1;
 
-                  return (
-                    <li
-                      key={track.id}
-                      className="relative flex gap-4 sm:gap-6 pb-6 last:pb-0"
-                    >
-                      {!isLast && (
-                        <span
-                          aria-hidden
-                          className="absolute left-[19px] sm:left-[23px] top-12 bottom-0 w-0.5 bg-gradient-to-b from-primary/40 to-primary/10"
-                        />
-                      )}
+                    // Lock if previous track is not yet completed
+                    const prevTrack = index > 0 ? roadmap.training_tracks[index - 1] : null;
+                    const prevEnrolled = prevTrack
+                      ? enrolledById.get(String(prevTrack.id))
+                      : null;
+                    const isPrevCompleted =
+                      index === 0 || (prevEnrolled?.progress_percentage ?? 0) === 100;
+                    const isLocked = isEnrolled && !isPrevCompleted;
 
-                      <div className="relative z-10 flex-shrink-0">
-                        <div
-                          className={`flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 rounded-full text-sm font-bold shadow-sm ring-4 ring-background ${
-                            isCompleted
-                              ? 'bg-emerald-600 text-white'
-                              : isEnrolled
-                                ? 'bg-primary text-primary-foreground'
-                                : 'bg-muted text-muted-foreground border border-border'
-                          }`}
-                        >
-                          {isCompleted ? (
-                            <CheckCircle2 className="w-5 h-5" />
-                          ) : !isEnrolled ? (
-                            <Lock className="w-4 h-4" />
-                          ) : (
-                            stepNumber
-                          )}
+                    return (
+                      <li
+                        key={track.id}
+                        className="relative flex gap-4 sm:gap-6 pb-6 last:pb-0"
+                      >
+                        {!isLast && (
+                          <span
+                            aria-hidden
+                            className="absolute left-[19px] sm:left-[23px] top-12 bottom-0 w-0.5 bg-gradient-to-b from-primary/40 to-primary/10"
+                          />
+                        )}
+
+                        <div className="relative z-10 flex-shrink-0">
+                          <div
+                            className={`flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 rounded-full text-sm font-bold shadow-sm ring-4 ring-background ${
+                              isCompleted
+                                ? 'bg-emerald-600 text-white'
+                                : isLocked || !isEnrolled
+                                  ? 'bg-muted text-muted-foreground border border-border'
+                                  : 'bg-primary text-primary-foreground'
+                            }`}
+                          >
+                            {isCompleted ? (
+                              <CheckCircle2 className="w-5 h-5" />
+                            ) : isLocked || !isEnrolled ? (
+                              <Lock className="w-4 h-4" />
+                            ) : (
+                              stepNumber
+                            )}
+                          </div>
                         </div>
-                      </div>
 
-                      <div className="flex-1 min-w-0">
-                        <div
-                          className={`rounded-lg border bg-card p-4 transition-all ${
-                            isEnrolled
-                              ? 'hover:shadow-md hover:border-primary/40'
-                              : 'opacity-60'
-                          }`}
-                        >
-                          <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-                            <div className="min-w-0 flex-1">
-                              <div className="flex items-center gap-2 mb-1 text-xs text-muted-foreground">
-                                <span className="font-medium">Step {stepNumber}</span>
-                                {track.platform && <span>• {track.platform}</span>}
-                                {track.category && (
-                                  <Badge
-                                    variant="outline"
-                                    className="text-[10px] py-0"
-                                  >
-                                    {track.category}
-                                  </Badge>
-                                )}
-                                {!isEnrolled && (
-                                  <Badge
-                                    variant="outline"
-                                    className="text-[10px] py-0 text-muted-foreground"
-                                  >
-                                    Not enrolled
-                                  </Badge>
-                                )}
-                              </div>
-                              <h3 className="font-semibold text-base sm:text-lg line-clamp-1">
-                                {track.title}
-                              </h3>
-                              {track.description && (
-                                <p className="text-sm text-muted-foreground line-clamp-2 mt-1">
-                                  {track.description}
-                                </p>
-                              )}
-
-                              <div className="flex flex-wrap items-center gap-3 mt-2 text-xs text-muted-foreground">
-                                <span className="flex items-center gap-1">
-                                  <BookOpen className="w-3.5 h-3.5" />
-                                  {enrolled?.completed_courses ?? 0} /{' '}
-                                  {enrolled?.total_courses ??
-                                    track.total_courses ??
-                                    track.courses?.length ??
-                                    0}{' '}
-                                  courses
-                                </span>
-                                {track.duration && (
-                                  <span className="flex items-center gap-1">
-                                    <Clock className="w-3.5 h-3.5" />
-                                    {track.duration}
-                                  </span>
-                                )}
-                              </div>
-
-                              {isEnrolled && (
-                                <div className="mt-3 max-w-xs">
-                                  <div className="flex items-center justify-between text-xs mb-1">
-                                    <span className="text-muted-foreground">
-                                      Progress
-                                    </span>
-                                    <span className="font-medium">
-                                      {Math.round(progressValue)}%
-                                    </span>
-                                  </div>
-                                  <Progress
-                                    value={progressValue}
-                                    className="h-1.5"
-                                  />
+                        <div className="flex-1 min-w-0">
+                          <div
+                            className={`rounded-lg border bg-card p-4 transition-all ${
+                              isEnrolled && !isLocked
+                                ? 'hover:shadow-md hover:border-primary/40'
+                                : 'opacity-60'
+                            }`}
+                          >
+                            <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+                              <div className="min-w-0 flex-1">
+                                <div className="flex items-center gap-2 mb-1 text-xs text-muted-foreground">
+                                  <span className="font-medium">Step {stepNumber}</span>
+                                  {track.platform && <span>• {track.platform}</span>}
+                                  {track.category && (
+                                    <Badge variant="outline" className="text-[10px] py-0">
+                                      {track.category}
+                                    </Badge>
+                                  )}
+                                  {!isEnrolled && (
+                                    <Badge variant="outline" className="text-[10px] py-0 text-muted-foreground">
+                                      Not enrolled
+                                    </Badge>
+                                  )}
+                                  {isLocked && (
+                                    <Badge variant="outline" className="text-[10px] py-0 text-amber-600 border-amber-400">
+                                      Complete previous step first
+                                    </Badge>
+                                  )}
                                 </div>
-                              )}
-                            </div>
+                                <h3 className="font-semibold text-base sm:text-lg line-clamp-1">
+                                  {track.title}
+                                </h3>
+                                {track.description && (
+                                  <p className="text-sm text-muted-foreground line-clamp-2 mt-1">
+                                    {track.description}
+                                  </p>
+                                )}
 
-                            <div className="flex-shrink-0 sm:w-32">
-                              {isEnrolled ? (
-                                <Button
-                                  size="sm"
-                                  className="w-full bg-primary hover:bg-primary/90"
-                                  onClick={() =>
-                                    onSelectCourse(String(track.id))
-                                  }
-                                >
-                                  {isCompleted ? 'Review' : 'Continue'}
-                                </Button>
-                              ) : (
-                                <Button
-                                  variant="outline"
-                                  size="sm"
-                                  className="w-full"
-                                  disabled
-                                >
-                                  Not enrolled
-                                </Button>
-                              )}
+                                <div className="flex flex-wrap items-center gap-3 mt-2 text-xs text-muted-foreground">
+                                  <span className="flex items-center gap-1">
+                                    <BookOpen className="w-3.5 h-3.5" />
+                                    {enrolled?.completed_courses ?? 0} /{' '}
+                                    {enrolled?.total_courses ??
+                                      track.total_courses ??
+                                      track.courses?.length ??
+                                      0}{' '}
+                                    courses
+                                  </span>
+                                  {track.duration && (
+                                    <span className="flex items-center gap-1">
+                                      <Clock className="w-3.5 h-3.5" />
+                                      {track.duration}
+                                    </span>
+                                  )}
+                                </div>
+
+                                {isEnrolled && (
+                                  <div className="mt-3 max-w-xs">
+                                    <div className="flex items-center justify-between text-xs mb-1">
+                                      <span className="text-muted-foreground">Progress</span>
+                                      <span className="font-medium">{Math.round(progressValue)}%</span>
+                                    </div>
+                                    <Progress value={progressValue} className="h-1.5" />
+                                  </div>
+                                )}
+                              </div>
+
+                              <div className="flex-shrink-0 sm:w-32">
+                                {isEnrolled ? (
+                                  <Button
+                                    size="sm"
+                                    className="w-full bg-primary hover:bg-primary/90"
+                                    disabled={isLocked}
+                                    onClick={() =>
+                                      !isLocked && onSelectCourse(String(track.id))
+                                    }
+                                  >
+                                    {isLocked ? (
+                                      <><Lock className="w-3.5 h-3.5 mr-1" /> Locked</>
+                                    ) : isCompleted ? (
+                                      'Review'
+                                    ) : (
+                                      'Continue'
+                                    )}
+                                  </Button>
+                                ) : (
+                                  <Button variant="outline" size="sm" className="w-full" disabled>
+                                    Not enrolled
+                                  </Button>
+                                )}
+                              </div>
                             </div>
                           </div>
                         </div>
-                      </div>
-                    </li>
-                  );
-                })}
-              </ol>
-            </CardContent>
+                      </li>
+                    );
+                  })}
+                </ol>
+              </CardContent>
+            )}
           </Card>
         );
       })}

--- a/src/shared/components/common/SidebarItem.tsx
+++ b/src/shared/components/common/SidebarItem.tsx
@@ -16,7 +16,7 @@ export default function SidebarItem({ item }: SidebarItemProps) {
 
   const isActive =
     location.pathname === itemPathname &&
-    (itemTab ?? null) === (currentTab ?? null)
+    (itemTab === null || itemTab === currentTab)
 
   const handleClick = () => {
     if (item.path.startsWith("http://") || item.path.startsWith("https://")) {

--- a/src/shared/config/navigation.config.ts
+++ b/src/shared/config/navigation.config.ts
@@ -1,4 +1,4 @@
-import { BookOpen, Calendar, HelpCircle, Settings, Users2, Target, MessageSquare, Search, Route } from "lucide-react"
+import { BookOpen, Calendar, HelpCircle, Settings, Users2, Target, MessageSquare, Search } from "lucide-react"
 import { LucideIcon } from "lucide-react"
 
 export interface NavItem {
@@ -18,8 +18,7 @@ export const CONSULTANT_NAV: NavSection[] = [
     title: "Main Menu",
     items: [
       { label: "My Progress", icon: BookOpen, path: "/courses", active: true },
-      { label: "Training Catalog", icon: Search, path: "/catalog" },
-      { label: "Roadmaps", icon: Route, path: "/catalog?tab=roadmaps" },
+      { label: "Catalog", icon: Search, path: "/catalog" },
       { label: "Training Schedule", icon: Calendar, path: "/schedule" },
       //{ label: "Course Resources", icon: BookOpen, path: "/resources" },
     ],
@@ -40,8 +39,7 @@ export const LEADER_NAV: NavSection[] = [
     title: "Main Menu",
     items: [
       { label: "My Progress", icon: BookOpen, path: "/courses", active: true },
-      { label: "Training Catalog", icon: Search, path: "/catalog" },
-      { label: "Roadmaps", icon: Route, path: "/catalog?tab=roadmaps" },
+      { label: "Catalog", icon: Search, path: "/catalog" },
       { label: "Team Overview", icon: Users2, path: "/leader/dashboard" },
       //{ label: "Performance Reports", icon: BarChart3, path: "/leader/reports" },
       { label: "Calendar", icon: Target, path: "/leader/plans" },
@@ -64,8 +62,7 @@ export const HR_NAV: NavSection[] = [
     title: "HR",
     items: [
       { label: "My Progress", icon: BookOpen, path: "/courses", active: true },
-      { label: "Training Catalog", icon: Search, path: "/catalog" },
-      { label: "Roadmaps", icon: Route, path: "/catalog?tab=roadmaps" },
+      { label: "Catalog", icon: Search, path: "/catalog" },
       { label: "Team Overview", icon: Users2, path: "/hr/dashboard" },
       //{ label: "Performance Reports", icon: BarChart3, path: "/leader/reports" },
       { label: "Calendar", icon: Target, path: "/hr/plans" },

--- a/src/shared/store/coursesApi.ts
+++ b/src/shared/store/coursesApi.ts
@@ -246,6 +246,15 @@ export const coursesApi = createApi({
       invalidatesTags: ['Courses', 'Progress'],
     }),
 
+    // Enroll in a full roadmap (single request → single email)
+    enrollInRoadmap: builder.mutation<{ enrolled_assignments: number[] }, string>({
+      query: (roadmapId) => ({
+        url: `/roadmaps/${roadmapId}/enroll/`,
+        method: 'POST',
+      }),
+      invalidatesTags: ['Courses', 'Progress'],
+    }),
+
     // Update course progress with file upload support
     updateCourseProgress: builder.mutation<TrainingTrack, FormData>({
       query: (formData) => {
@@ -291,6 +300,7 @@ export const {
   useGetUserProgressQuery,
   useGetScheduleQuery,
   useEnrollInCourseMutation,
+  useEnrollInRoadmapMutation,
   useUpdateCourseProgressMutation,
   useDeleteCourseSubmissionMutation,
 } = coursesApi


### PR DESCRIPTION
Summary
Mejoras a la funcionalidad de Roadmaps: catálogo filtrable, inscripción por roadmap completo y progreso secuencial.

Changes
Catalog — Roadmaps tab

Replaced the sidebar-style tab pill with a full-width horizontal underline tab bar; removed Roadmaps as a separate sidebar entry (Catalog stays active for both tabs)
Fixed sidebar active state so the Catalog item highlights regardless of ?tab param
Added FilterControls to the Roadmaps tab: category filter, platform filter, and A–Z / Z–A sort — populated dynamically from the tracks inside each roadmap
Added card / table view toggle (preference persisted to localStorage) and pagination (5 roadmaps per page)
Made each roadmap card collapsible/expandable via a chevron toggle
Removed per-track Enroll buttons — enrollment is now roadmap-level only, preventing users from accidentally enrolling in a single track instead of the full path
Fixed a bug where roadmaps showed as fully enrolled due to the catalog API's enrolled flag being included in enrolledIds; enrollment status now derives exclusively from the enrolled-courses endpoint
Switched handleEnrollRoadmap to use the new enrollInRoadmap single-request mutation
My Progress — Roadmap view

Made each roadmap card collapsible/expandable (all start expanded)
Added sequential locking: tracks beyond step 1 are disabled until the previous track reaches 100% progress; locked tracks show a warning badge and a disabled Locked button
API

Added enrollInRoadmap mutation (POST /roadmaps/:id/enroll/)
Improved enroll error messages to surface the backend message instead of a hardcoded string